### PR TITLE
Logging wrapper using python's logging module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,15 @@ scripts/
 img/
 .DS_Store
 mudpi.config
+
+# Python compiled
+__pycache__/
+
+# Virtual Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,18 @@ scripts/
 img/
 .DS_Store
 mudpi.config
+
+# Python compiled
+__pycache__/
+
+# Virtual Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# IDE configs
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ venv.bak/
 
 # IDE configs
 .idea/
+
+
+*.log

--- a/config_load.py
+++ b/config_load.py
@@ -1,19 +1,22 @@
-import json 
+import json
+
 
 def saveConfig(configs):
-	with open(str(input('Config File Name: ')), 'w') as outfile:  
-		json.dump(configs, outfile, indent=4)
-		#outfile.close()
+    with open(str(input('Config File Name: ')), 'w') as outfile:
+        json.dump(configs, outfile, indent=4)
+    # outfile.close()
 
-def loadConfigJson(configs):
-	with open('mudpi.config') as loadedfile:
-		configs = json.load(loadedfile)
-		return configs
-		loadedfile.close()
+
+def loadConfigJson():
+    with open('mudpi.config') as loadedfile:
+        configs = json.load(loadedfile)
+        loadedfile.close()
+        return configs
+
 
 def loadConfig(configs):
-	with open("config.mud") as configfile:
-		for line in configfile:
-			name, var = line.partition("=")[::2]
-			configs[name.strip()] = (var)
-		configfile.close()
+    with open("config.mud") as configfile:
+        for line in configfile:
+            name, var = line.partition("=")[::2]
+            configs[name.strip()] = (var)
+        configfile.close()

--- a/logger/Logger.py
+++ b/logger/Logger.py
@@ -1,0 +1,75 @@
+import logging
+import sys
+
+LOG_LEVEL = {  # low effort enum
+    "unknown": logging.NOTSET,
+    "critical": logging.CRITICAL,
+    "error": logging.ERROR,
+    "warning": logging.WARNING,
+    "info": logging.INFO,
+    "debug": logging.DEBUG,
+}
+
+
+class Logger:
+
+    loggers = {}
+    CONFIG = None
+
+    def __init__(self, config: dict):
+        if config is None:  # No config given, using sane defaults
+            if Logger.CONFIG is None:  # not seen a config before
+                config = {
+                    'name': 'MudPi',
+                    'log_level': logging.WARNING,
+                    'log_file': '/tmp/mudpi.log'
+                }
+            else:
+                config = Logger.CONFIG  # use previously seen config
+        else:
+            Logger.CONFIG = config
+
+        self.log = logging.getLogger(config['name'])  # starting loggers
+        try:
+            log_level = LOG_LEVEL[config['log_level']]
+        except KeyError:
+            log_level = LOG_LEVEL['unknown']
+        self.log.setLevel(log_level)
+
+        try:
+            open(config['log_file'], 'w').close()  # testing file path, error if not valid
+            handler = logging.FileHandler(config['log_file'])
+            handler.setLevel(log_level)
+        except FileNotFoundError or KeyError:
+            handler = logging.Handler()
+            print("Not going to write log to file ...")
+
+        stream_handler = logging.StreamHandler(sys.stdout)
+        stream_handler.setLevel(logging.WARNING)  # only send WARNING or higher to stdout
+
+        formatter = logging.Formatter("[%(asctime)s][%(name)s][%(levelname)s] %(message)s")
+        handler.setFormatter(formatter)
+
+        formatter = logging.Formatter("[%(asctime)s][%(name)s][%(levelname)s] %(message)s",
+                                      "%H:%M:%S")
+        stream_handler.setFormatter(formatter)
+
+        self.log.addHandler(handler)
+        self.log.addHandler(stream_handler)
+
+
+    @staticmethod
+    def get_logger(name: str = "Main", config: dict = None) -> logging.Logger:
+        """
+        Method to grab the current specified loggers instance or create one if missing
+        :param name: loggers name to return, defaults to the Main loggers
+        :param config:
+        :return:
+        """
+
+        if name not in Logger.loggers.keys():
+            Logger.loggers[name] = Logger(config).log
+
+            if len(Logger.loggers.keys()) == 1:  # just created main/first logger
+                Logger.loggers["Main"] = Logger.loggers[name]
+        return Logger.loggers[name]

--- a/mudpi.config.example
+++ b/mudpi.config.example
@@ -1,6 +1,7 @@
 {
     "name": "MudPi",
-    "debug": false,
+    "log_level": "debug",
+    "log_file": "./mudpi.log",
     "server": {
         "host": "127.0.0.1",
         "port": 6602

--- a/mudpi.py
+++ b/mudpi.py
@@ -5,9 +5,11 @@ import socket
 import time
 import json
 import sys
+
 sys.path.append('..')
 from config_load import loadConfigJson
 from server.mudpi_server import MudpiServer
+
 from workers.lcd_worker import LCDWorker
 from workers.relay_worker import RelayWorker
 from workers.camera_worker import CameraWorker
@@ -16,30 +18,33 @@ from workers.arduino_worker import ArduinoWorker
 from workers.pi_sensor_worker import PiSensorWorker
 from workers.pi_control_worker import PiControlWorker
 from workers.arduino_control_worker import ArduinoControlWorker
+
 import variables
+from logger.Logger import Logger
 
 # __  __           _ _____ _ 
-#|  \/  |         | |  __ (_)
-#| \  / |_   _  __| | |__) | 
-#| |\/| | | | |/ _` |  ___/ |
-#| |  | | |_| | (_| | |   | |
-#|_|  |_|\__,_|\__,_|_|   |_|
+# |  \/  |         | |  __ (_)
+# | \  / |_   _  __| | |__) |
+# | |\/| | | | |/ _` |  ___/ |
+# | |  | | |_| | (_| | |   | |
+# |_|  |_|\__,_|\__,_|_|   |_|
 # https://mudpi.app
 
-CONFIGS = {}
 PROGRAM_RUNNING = True
 print(chr(27) + "[2J")
 print('Loading MudPi Configs...\r', end="", flush=True)
-#load the configuration
-CONFIGS = loadConfigJson(CONFIGS)
-#Waiting for redis and services to be running
-time.sleep(5) 
+# load the configuration
+CONFIGS = loadConfigJson()
+# Waiting for redis and services to be running
+time.sleep(5)
 print('Loading MudPi Configs...\t\033[1;32m Complete\033[0;0m')
 time.sleep(1)
 
-#Clear the console if its open for debugging                           
+log = Logger.get_logger(config=CONFIGS)
+
+# Clear the console if its open for debugging
 print(chr(27) + "[2J")
-#Print a display logo for startup
+# Print a display logo for startup
 print("\033[1;32m")
 print(' __  __           _ _____ _ ')
 print('|  \/  |         | |  __ (_)')
@@ -53,170 +58,175 @@ print('Eric Davisson @theDavisson')
 print('Version: ', CONFIGS.get('version', '0.8.3'))
 print('\033[0;0m')
 
-if CONFIGS['debug'] is True:
-	print('\033[1;33mDEBUG MODE ENABLED\033[0;0m')
-	print("Loaded Config\n--------------------")
-	for index, config in CONFIGS.items():
-		if config != '':
-			print('%s: %s' % (index, config))
-	time.sleep(10)
+if CONFIGS['log_level'] == 'debug':
+    print('\033[1;33mDEBUG MODE ENABLED\033[0;0m')
+    print("Loaded Config\n--------------------")
+    for index, config in CONFIGS.items():
+        if config != '':
+            print('%s: %s' % (index, config))
+    time.sleep(10)
 
 try:
-	print('Initializing Garden Control \r', end="", flush=True)
-	GPIO.setwarnings(False)
-	GPIO.setmode(GPIO.BCM)
-	GPIO.cleanup()
-	#Pause for GPIO to finish
-	time.sleep(0.1)
-	print('Initializing Garden Control...\t\t\033[1;32m Complete\033[0;0m')
-	print('Preparing Threads for Workers\r', end="", flush=True)
+    print('Initializing Garden Control \r', end="", flush=True)
+    GPIO.setwarnings(False)
+    GPIO.setmode(GPIO.BCM)
+    GPIO.cleanup()
+    # Pause for GPIO to finish
+    time.sleep(0.1)
+    print('Initializing Garden Control...\t\t\033[1;32m Complete\033[0;0m')
+    print('Preparing Threads for Workers\r', end="", flush=True)
 
-	threads = []
-	relays = []
-	relayEvents = {}
-	relay_index = 0
-	variables.lcd_message = {'line_1': 'Mudpi Control', 'line_2': 'Is Now Running'}
+    threads = []
+    relays = []
+    relayEvents = {}
+    relay_index = 0
+    variables.lcd_message = {'line_1': 'Mudpi Control', 'line_2': 'Is Now Running'}
 
-	new_messages_waiting = threading.Event() #Event to signal LCD to pull new messages
-	main_thread_running = threading.Event() #Event to signal workers to close
-	system_ready = threading.Event() #Event to tell workers to begin working
-	camera_available = threading.Event() #Event to signal if camera can be used
-	main_thread_running.set() #Main event to tell workers to run/shutdown
+    new_messages_waiting = threading.Event()  # Event to signal LCD to pull new messages
+    main_thread_running = threading.Event()  # Event to signal workers to close
+    system_ready = threading.Event()  # Event to tell workers to begin working
+    camera_available = threading.Event()  # Event to signal if camera can be used
+    main_thread_running.set()  # Main event to tell workers to run/shutdown
 
-	time.sleep(0.1)
-	print('Preparing Threads for Workers...\t\033[1;32m Complete\033[0;0m')
+    time.sleep(0.1)
+    print('Preparing Threads for Workers...\t\033[1;32m Complete\033[0;0m')
 
-	#l = LCDWorker(new_messages_waiting,main_thread_running,system_ready)
-	#print('Loading LCD Worker')
-	#l = l.run()
-	#threads.append(l)
+    # l = LCDWorker(new_messages_waiting,main_thread_running,system_ready)
+    # print('Loading LCD Worker')
+    # l = l.run()
+    # threads.append(l)
 
-	# Worker for Camera
-	try:
-		c = CameraWorker(CONFIGS['camera'], main_thread_running, system_ready, camera_available)
-		print('Loading Pi Camera Worker')
-		c = c.run()
-		threads.append(c)
-		camera_available.set()
-	except KeyError:
-		print('No Camera Found to Load')
+    # Worker for Camera
+    try:
+        c = CameraWorker(CONFIGS['camera'], main_thread_running, system_ready, camera_available)
+        log.debug('Loading Pi Camera Worker')
+        c = c.run()
+        threads.append(c)
+        camera_available.set()
+    except KeyError:
+        log.debug('No Camera Found to Load')
 
-	# Workers for pi (Sensors, Controls, Relays)
-	try:
-		for worker in CONFIGS['workers']:
-			# Create worker for worker
-			if worker['type'] == "sensor":
-				pw = PiSensorWorker(worker, main_thread_running, system_ready)
-				print('Loading Pi Sensor Worker')
-			elif worker['type'] == "control":
-				pw = PiControlWorker(worker, main_thread_running, system_ready)
-				print('Loading Pi Control Worker')
-			elif worker['type'] == "relay":
-				# Add Relay Worker Here for Better Config Control
-				print('Loading Pi Relay Worker')
-			else:
-				raise Exception("Unknown Worker Type: " + worker['type'])
-			pw = pw.run()
-			if pw is not None:
-				threads.append(pw)
-	except KeyError:
-		print('No Pi Workers Found to Load or Invalid Type')
+    # Workers for pi (Sensors, Controls, Relays)
+    try:
+        for worker in CONFIGS['workers']:
+            # Create worker for worker
+            if worker['type'] == "sensor":
+                pw = PiSensorWorker(worker, main_thread_running, system_ready)
+                log.debug('Loading Pi Sensor Worker')
+            elif worker['type'] == "control":
+                pw = PiControlWorker(worker, main_thread_running, system_ready)
+                log.debug('Loading Pi Control Worker')
+            elif worker['type'] == "relay":
+                # Add Relay Worker Here for Better Config Control
+                log.debug('Loading Pi Relay Worker')
+            else:
+                log.critical("Unknown Worker Type: {0}".format(worker['type']))
+                raise Exception("Unknown Worker Type: " + worker['type'])
+            pw = pw.run()
+            if pw is not None:
+                threads.append(pw)
+    except KeyError:
+        log.debug('No Pi Workers Found to Load or Invalid Type')
 
+    # Worker for relays attached to pi
+    try:
+        for relay in CONFIGS['relays']:
+            # Create a threading event for each relay to check status
+            relayState = {
+                "available": threading.Event(),  # Event to allow relay to activate
+                "active": threading.Event()  # Event to signal relay to open/close
+            }
+            # Store the relays under the key or index if no key is found, this way we can reference the right relays
+            relayEvents[relay.get("key", relay_index)] = relayState
+            # Create sensor worker for a relay
+            r = RelayWorker(relay, main_thread_running, system_ready, relayState['available'],
+                            relayState['active'])
+            r = r.run()
+            # Make the relays available, this event is toggled off elsewhere if we need to disable relays
+            relayState['available'].set()
+            relay_index += 1
+            if r is not None:
+                threads.append(r)
+    except KeyError:
+        log.debug('No Relays Found to Load')
 
-	# Worker for relays attached to pi
-	try:
-		for relay in CONFIGS['relays']:
-			#Create a threading event for each relay to check status
-			relayState = {
-				"available": threading.Event(), #Event to allow relay to activate
-				"active": threading.Event() #Event to signal relay to open/close
-			}
-			#Store the relays under the key or index if no key is found, this way we can reference the right relays
-			relayEvents[relay.get("key", relay_index)] = relayState
-			#Create sensor worker for a relay
-			r = RelayWorker(relay, main_thread_running, system_ready, relayState['available'], relayState['active'])
-			r = r.run()
-			#Make the relays available, this event is toggled off elsewhere if we need to disable relays
-			relayState['available'].set()
-			relay_index +=1
-			if r is not None:
-				threads.append(r)
-	except KeyError:
-		print('No Relays Found to Load')
-
-	# Worker for nodes attached to pi via serial or wifi[esp8266]
-	# Supported nodes: arduinos, esp8266, ADC-MCP3xxx, probably others
-	try:
-		for node in CONFIGS['nodes']:
-			# Create worker for node
-			if node['type'] == "arduino":
-				t = ArduinoWorker(node, main_thread_running, system_ready)
-				if node['controls'] is not None:
-					acw = ArduinoControlWorker(node, main_thread_running, system_ready, t.connection)
-					acw = acw.run()
-					if acw is not None:
-						threads.append(acw)
-			elif node['type'] == "ADC-MCP3008":
-				t = ADCMCP3008Worker(node, main_thread_running, system_ready)
-			else:
-				raise Exception("Unknown Node Type: " + node['type'])
-			t = t.run()
-			if t is not None:
-				threads.append(t)
-	except KeyError:
-		print('Invalid or no Nodes found to Load')
-
-
-	#Decided not to build server worker (this is replaced with nodejs, expressjs)
-	#Maybe use this for internal communication across devices if using wireless
-	def server_worker():
-		server.listen()
-	print('Initializing Server')
-	server = MudpiServer(main_thread_running, CONFIGS['server']['host'], CONFIGS['server']['port'])
-	s = threading.Thread(target=server_worker)
-	threads.append(s)
-	s.start()
+    # Worker for nodes attached to pi via serial or wifi[esp8266]
+    # Supported nodes: arduinos, esp8266, ADC-MCP3xxx, probably others
+    try:
+        for node in CONFIGS['nodes']:
+            # Create worker for node
+            if node['type'] == "arduino":
+                log.debug("Starting Arduino Worker...")
+                t = ArduinoWorker(node, main_thread_running, system_ready)
+                if node['controls'] is not None:
+                    acw = ArduinoControlWorker(node, main_thread_running, system_ready,
+                                               t.connection)
+                    acw = acw.run()
+                    if acw is not None:
+                        threads.append(acw)
+            elif node['type'] == "ADC-MCP3008":
+                log.debug("Starting ADC-MCP3008 Worker...")
+                t = ADCMCP3008Worker(node, main_thread_running, system_ready)
+            else:
+                log.critical("Unknown Node Type: {0}".format(node['type']))
+                raise Exception("Unknown Node Type: " + node['type'])
+            t = t.run()
+            if t is not None:
+                threads.append(t)
+    except KeyError:
+        log.debug('Invalid or no Nodes found to Load')
 
 
-	time.sleep(.5)
-	print('MudPi Garden Control...\t\t\t\033[1;32m Online\033[0;0m')
-	print('_________________________________________________')
-	system_ready.set() #Workers will not process until system is ready
-	variables.r.set('started_at', str(datetime.datetime.now())) #Store current time to track uptime
-	system_message = {'event':'SystemStarted', 'data':1}
-	variables.r.publish('mudpi', json.dumps(system_message))
-	
+    # Decided not to build server worker (this is replaced with nodejs, expressjs)
+    # Maybe use this for internal communication across devices if using wireless
+    def server_worker():
+        server.listen()
 
-	#Hold the program here until its time to graceful shutdown
-	#This is our pump cycle check, Using redis to determine if pump should activate
-	while PROGRAM_RUNNING:
-		# Main program loop
-		# add logging or other system operations here...
-		time.sleep(0.1)
+
+    log.info('Initializing Server...')
+    server = MudpiServer(main_thread_running, CONFIGS['server']['host'], CONFIGS['server']['port'])
+    s = threading.Thread(target=server_worker)
+    threads.append(s)
+    s.start()
+
+    time.sleep(.5)
+    print('MudPi Garden Control...\t\t\t\033[1;32m Online\033[0;0m')
+    print('_________________________________________________')
+    system_ready.set()  # Workers will not process until system is ready
+    variables.r.set('started_at',
+                    str(datetime.datetime.now()))  # Store current time to track uptime
+    system_message = {'event': 'SystemStarted', 'data': 1}
+    variables.r.publish('mudpi', json.dumps(system_message))
+
+    # Hold the program here until its time to graceful shutdown
+    # This is our pump cycle check, Using redis to determine if pump should activate
+    while PROGRAM_RUNNING:
+        # Main program loop
+        # add log or other system operations here...
+        time.sleep(0.1)
 
 except KeyboardInterrupt:
-	PROGRAM_RUNNING = False
+    PROGRAM_RUNNING = False
 finally:
-	print('MudPi Shutting Down...')
-	#Perform any cleanup tasks here...
+    log.info('MudPi Shutting Down...')
+    # Perform any cleanup tasks here...
 
-	#load a client on the server to clear it from waiting
-	# sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-	#sock.connect((CONFIGS['SERVER_HOST'], int(CONFIGS['SERVER_PORT'])))
-	server.sock.shutdown(socket.SHUT_RDWR)
-	# time.sleep(1)
-	# sock.close()
-	
-	#Clear main running event to signal threads to close
-	main_thread_running.clear()
+    # load a client on the server to clear it from waiting
+    # sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    # sock.connect((config['SERVER_HOST'], int(config['SERVER_PORT'])))
+    server.sock.shutdown(socket.SHUT_RDWR)
+    # time.sleep(1)
+    # sock.close()
 
-	#Shutdown the camera loop
-	camera_available.clear()
+    # Clear main running event to signal threads to close
+    main_thread_running.clear()
 
-	#Join all our threads for shutdown
-	for thread in threads:
-		thread.join()
+    # Shutdown the camera loop
+    camera_available.clear()
 
-	print("MudPi Shutting Down...\t\t\t\033[1;32m Complete\033[0;0m")
-	print("Mudpi is Now...\t\t\t\t\033[1;31m Offline\033[0;0m")
-	
+    # Join all our threads for shutdown
+    for thread in threads:
+        thread.join()
+
+    print("MudPi Shutting Down...\t\t\t\033[1;32m Complete\033[0;0m")
+    print("Mudpi is Now...\t\t\t\t\033[1;31m Offline\033[0;0m")


### PR DESCRIPTION
I've wrote a wrapper around python's in-built logging module for easy logging inside MudPi.
The exact log format is up for debate and is easily adjustable within **logger/Logger.py**

## Pending Changes
I've yet to change the old code to use the new logging. I thought log level usage as well as what should remain simple prints to preserve the __neat look__ of MudPi during boot worth a talk.
But I have changed several prints like `print('No Relays Found to Load')` as they were not part of the graphical look of MudPi's booting and also valuable to be logged to file for debugging.

## Logging Options

### Different Formats
The logging module allows options like the exact logging format to be individually changed per "handler". This allows for example the __stream_handler__ which outputs the logging to _stdout_
to have a different format than what is written inside the .log file.

I've also tested with a less verbose output on _stdout_ to not flood the "look" with a different log format too much (Warning or higher). This is currently not configurable but could be.

#### Example
##### mudpi.log
```
[2019-10-13 18:43:58,665][MudPi][DEBUG] No Camera Found to Load
[2019-10-13 18:43:58,669][MudPi][DEBUG] No Relays Found to Load
[2019-10-13 18:43:58,824][MudPi][INFO] Initializing Server...
[2019-10-13 18:43:58,825][MudPi][WARNING] TEST WARNING for stdout
[2019-10-13 18:44:15,098][MudPi][INFO] MudPi Shutting Down...
```

##### stdout 
```
[13:29:24][MudPi][WARNING] TEST WARNING for stdout
```

### New Configuration Options
I've changed __debug__ into __log_level__ with string names of the relevant log level which should be logged. If a high log level is set in the config, lower log levels will be completely ignored and not appear in the logging system.

A log level of "debug" will also trigger the configuration dump like previously _true_ did.

A list of all available log levels is here:
##### logger/Logger.py
```
LOG_LEVEL = { 
    "unknown": logging.NOTSET,
    "critical": logging.CRITICAL,
    "error": logging.ERROR,
    "warning": logging.WARNING,
    "info": logging.INFO,
    "debug": logging.DEBUG,
}
```

It should be noted that __critical__ is higher than __error__.

I've also added __log_file__ to specify the log file path.

## Other Edits

### .gitignore
I've added typical folders for virtual environments, python compiled/binary files, *.log files and pyCharms configuration folder.

### config_load.py
I noticed the parameter _CONFIGS_ to be unused/unneeded and the line to close the file stream to have been unreachable and fixed that and relevant usage of the function.

### Converted Tabs to 4 Spaces
Did that more out of habit and because it's [PEP-008](https://www.python.org/dev/peps/pep-0008/) and I've spaces and tabs mixed. There should be a decision on what to use.