### PR TITLE
Fixed Issue with MCP3xxx Sensors

### DIFF
--- a/mudpi.py
+++ b/mudpi.py
@@ -64,7 +64,7 @@ print('|_|  |_|\__,_|\__,_|_|   |_| ')
 print('_________________________________________________')
 print('')
 print('Eric Davisson @theDavisson')
-print('Version: ', CONFIGS.get('version', '0.8.6'))
+print('Version: ', CONFIGS.get('version', '0.8.7'))
 print('\033[0;0m')
 
 if CONFIGS['debug'] is True:

--- a/mudpi.py
+++ b/mudpi.py
@@ -5,6 +5,7 @@ import socket
 import time
 import json
 import sys
+import traceback
 sys.path.append('..')
 from action import Action
 from config_load import loadConfigJson
@@ -135,6 +136,7 @@ try:
 				threads.append(pw)
 	except KeyError:
 		print('No Pi Workers Found to Load or Invalid Type')
+		traceback.print_exc()
 
 
 	# Worker for relays attached to pi
@@ -157,6 +159,7 @@ try:
 				threads.append(r)
 	except KeyError:
 		print('No Relays Found to Load')
+		traceback.print_exc()
 
 	# Worker for nodes attached to pi via serial or wifi[esp8266]
 	# Supported nodes: arduinos, esp8266, ADC-MCP3xxx, probably others
@@ -178,8 +181,9 @@ try:
 			t = t.run()
 			if t is not None:
 				threads.append(t)
-	except KeyError:
+	except KeyError as e:
 		print('Invalid or no Nodes found to Load')
+		traceback.print_exc()
 
 
 	# Load in Actions
@@ -190,6 +194,7 @@ try:
 			actions[a.key] = a
 	except KeyError:
 		print('No Actions Found to Load')
+		traceback.print_exc()
 
 	# Worker for Triggers
 	try:
@@ -199,6 +204,7 @@ try:
 		threads.append(t)
 	except KeyError:
 		print('No Triggers Found to Load')
+		traceback.print_exc()
 
 
 	#Decided not to build server worker (this is replaced with nodejs, expressjs)

--- a/sensors/MCP3xxx/sensor.py
+++ b/sensors/MCP3xxx/sensor.py
@@ -5,14 +5,14 @@ import adafruit_mcp3xxx.mcp3008 as MCP
 class Sensor:
 
     PINS = {
-        '0': MCP.P0,
-        '1': MCP.P1,
-        '2': MCP.P2,
-        '3': MCP.P3,
-        '4': MCP.P4,
-        '5': MCP.P5,
-        '6': MCP.P6,
-        '7': MCP.P7,
+        0: MCP.P0,
+        1: MCP.P1,
+        2: MCP.P2,
+        3: MCP.P3,
+        4: MCP.P4,
+        5: MCP.P5,
+        6: MCP.P6,
+        7: MCP.P7,
     }
 
     def __init__(self, pin: int, mcp, name='Sensor', key=None):


### PR DESCRIPTION
## MCP3xxx KeyError
There was a contradiction of the Pins of the MCP3xxx being specified as strings while the input was always casted to int.
The Pins are now referenced internally via Integer and correctly cast strings (containing numbers) to it. No Config change should be needed.

## KeyErrors in mudpi.py
Also added stack traces to be printed for many KeyErrors inside `mudpi.py` to help with future troubleshooting. 
This will **not interrupt** the program though and introduced `traceback` as an import.

I've also omitted keys like `'camera'` as they are no list that can be kept empty.