### PR TITLE
Logging Class (using Python's logging module)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ scripts/
 tests/
 img/
 mudpi.config
+*.log
 # Python compiled
 __pycache__/
 

--- a/logger/Logger.py
+++ b/logger/Logger.py
@@ -1,0 +1,99 @@
+import logging
+import sys
+
+config = {
+    "logging": {
+        "file_log_level": "debug",
+        "terminal_log_level": "info",
+        "file": "some/path/to/logFile"
+    }
+}  # Example Config  # TODO remove
+
+LOG_LEVEL = {
+    "unknown": logging.NOTSET,
+    "debug": logging.DEBUG,
+    "info": logging.INFO,
+    "warning": logging.WARN,
+    "critical": logging.CRITICAL,
+    "error": logging.ERROR,
+}
+
+class Logger:
+
+    logger = None
+
+    def __init__(self, config: dict):
+        if "logging" in config.keys():
+            logger_config = config["logging"]
+        else:
+            raise Exception("No Logger configs were found!")
+        
+        self.__log = logging.getLogger(config['name']+"_stream")
+        self.__file_log = logging.getLogger(config['name'])
+
+        try:
+            file_log_level = LOG_LEVEL[logger_config["file_log_level"]] if not config["debug"] else LOG_LEVEL["debug"]
+            stream_log_level = LOG_LEVEL[logger_config["terminal_log_level"]] if not config["debug"] else LOG_LEVEL["debug"]
+        except KeyError:
+            file_log_level = LOG_LEVEL["unknown"]
+            stream_log_level = LOG_LEVEL["unknown"]
+        
+        self.__log.setLevel(stream_log_level)
+        self.__file_log.setLevel(file_log_level)
+
+        try:
+            try:
+                if len(logger_config['file']) != 0:
+                    open(logger_config['file'], 'w').close()  # testing file path
+                    file_handler = logging.FileHandler(logger_config['file'])
+                    file_handler.setLevel(file_log_level)
+
+                    self.WRITE_TO_FILE = True
+                else:
+                    self.WRITE_TO_FILE = False
+            except FileNotFoundError:
+                self.WRITE_TO_FILE = False
+        
+        except KeyError as e:
+            self.WRITE_TO_FILE = False
+
+            self.log(LOG_LEVEL["warning"], "File Handler could not be started due to a KeyError: {0}".format(e))
+        
+        stream_handler = logging.StreamHandler(sys.stdout)
+        stream_handler.setLevel(stream_log_level)
+
+        file_formatter = logging.Formatter("[%(asctime)s][%(name)s][%(levelname)s] %(message)s", "%H:%M:%S")
+        stream_formatter = logging.Formatter("%(message)s")
+        file_handler.setFormatter(file_formatter)
+        stream_handler.setFormatter(stream_formatter)
+
+        if self.WRITE_TO_FILE:
+            self.__file_log.addHandler(file_handler)
+        self.__log.addHandler(stream_handler)
+    
+    @staticmethod
+    def log_to_file(log_level: int, msg: str):
+        """
+        Logs the given message ONLY to the log file.
+        """
+        if Logger.log is not None:
+            Logger.logger.log_this_file(log_level, msg)
+    
+    @staticmethod
+    def log(log_level: int, msg: str):  # for ease of access from outside
+        """
+        Logs the given message to the terminal and possibly file.
+        """
+        if Logger.log is not None:
+            Logger.logger.log_this(log_level, msg)
+
+    def log_this_file(self, log_level: int, msg: str):
+        msg = msg.replace("\x1b[1;32m", "")
+        msg = msg.replace("\x1b[0;0m", "")
+        msg = msg.replace("\x1b[1;31m", "")
+        self.__file_log.log(log_level, msg)
+    
+    def log_this(self, log_level: int, msg: str):
+        self.__log.log(log_level, msg)
+        if self.WRITE_TO_FILE:
+            self.log_this_file(log_level, msg)

--- a/logger/Logger.py
+++ b/logger/Logger.py
@@ -1,13 +1,6 @@
 import logging
 import sys
 
-config = {
-    "logging": {
-        "file_log_level": "debug",
-        "terminal_log_level": "info",
-        "file": "some/path/to/logFile"
-    }
-}  # Example Config  # TODO remove
 
 LOG_LEVEL = {
     "unknown": logging.NOTSET,

--- a/mudpi.config.example
+++ b/mudpi.config.example
@@ -1,6 +1,11 @@
 {
     "name": "MudPi",
     "debug": false,
+    "logging": {
+        "file_log_level": "debug",
+        "terminal_log_level": "debug",
+        "file": "mudpi.log"
+    },
     "server": {
         "host": "127.0.0.1",
         "port": 6602

--- a/mudpi.py
+++ b/mudpi.py
@@ -10,7 +10,7 @@ sys.path.append('..')
 from action import Action
 from config_load import loadConfigJson
 from server.mudpi_server import MudpiServer
-#from workers.pi.lcd_worker import LcdWorker  # TODO only import this if LCD is required/available, causes crash otherwise
+from workers.pi.lcd_worker import LcdWorker
 from workers.pi.i2c_worker import PiI2CWorker	
 from workers.pi.relay_worker import RelayWorker
 from workers.pi.camera_worker import CameraWorker

--- a/mudpi.py
+++ b/mudpi.py
@@ -10,7 +10,7 @@ sys.path.append('..')
 from action import Action
 from config_load import loadConfigJson
 from server.mudpi_server import MudpiServer
-from workers.pi.lcd_worker import LcdWorker
+#from workers.pi.lcd_worker import LcdWorker  # TODO only import this if LCD is required/available, causes crash otherwise
 from workers.pi.i2c_worker import PiI2CWorker	
 from workers.pi.relay_worker import RelayWorker
 from workers.pi.camera_worker import CameraWorker
@@ -27,6 +27,8 @@ try:
 	MCP_ENABLED = True
 except ImportError:
 	MCP_ENABLED = False
+
+from logger.Logger import Logger, LOG_LEVEL
 import variables
 
 ##############################
@@ -82,13 +84,25 @@ if CONFIGS['debug'] is True:
 	time.sleep(10)
 
 try:
+	print('Initializing Logger \r', end="", flush=True)
+	Logger.logger = Logger(CONFIGS)
+	time.sleep(0.05)
+	Logger.log(LOG_LEVEL["info"], 'Initializing Logger...\t\t\t\033[1;32m Complete\033[0;0m')
+	Logger.log_to_file(LOG_LEVEL["debug"], "Dumping the config file: ")
+	for index, config in CONFIGS.items():
+			Logger.log_to_file(LOG_LEVEL["debug"], '%s: %s' % (index, config))
+	Logger.log_to_file(LOG_LEVEL["debug"], "End of config file dump!\n")
+except Exception as e:
+	Logger.log(LOG_LEVEL["info"], 'Initializing Logger...\t\t\t\033[1;31m Disabled\033[0;0m')
+
+try:
 	print('Initializing Garden Control \r', end="", flush=True)
 	GPIO.setwarnings(False)
 	GPIO.setmode(GPIO.BCM)
 	GPIO.cleanup()
 	# Pause for GPIO to finish
 	time.sleep(0.1)
-	print('Initializing Garden Control...\t\t\033[1;32m Complete\033[0;0m')
+	Logger.log(LOG_LEVEL["info"], 'Initializing Garden Control...\t\t\033[1;32m Complete\033[0;0m')
 	print('Preparing Threads for Workers\r', end="", flush=True)
 
 	new_messages_waiting = threading.Event() 	# Event to signal LCD to pull new messages
@@ -99,18 +113,18 @@ try:
 
 	main_thread_running.set() 					# Main event to tell workers to run/shutdown
 	time.sleep(0.1)
-	print('Preparing Threads for Workers...\t\033[1;32m Complete\033[0;0m')
+	Logger.log(LOG_LEVEL["info"], 'Preparing Threads for Workers...\t\033[1;32m Complete\033[0;0m')
 
 	# Worker for Camera
 	try:
 		if len(CONFIGS["camera"]) > 0:
 			CONFIGS["camera"]["redis"] = r
 			c = CameraWorker(CONFIGS['camera'], main_thread_running, system_ready, camera_available)
-			print('MudPi Camera...\t\t\t\033[1;32m Initializing\033[0;0m')
+			Logger.log(LOG_LEVEL["info"], 'MudPi Camera...\t\t\t\033[1;32m Initializing\033[0;0m')
 			workers.append(c)
 			camera_available.set()
 	except KeyError:
-		print('MudPi Pi Camera...\t\t\t\033[1;31m Disabled\033[0;0m')
+		Logger.log(LOG_LEVEL["info"], 'MudPi Pi Camera...\t\t\t\033[1;31m Disabled\033[0;0m')
 
 	# Workers for pi (Sensors, Controls, Relays, I2C)
 	try:
@@ -120,27 +134,28 @@ try:
 				worker["redis"] = r
 				if worker['type'] == "sensor":
 					pw = PiSensorWorker(worker, main_thread_running, system_ready)
-					print('MudPi Sensors...\t\t\t\033[1;32m Initializing\033[0;0m')
+					Logger.log(LOG_LEVEL["info"], 'MudPi Sensors...\t\t\t\033[1;32m Initializing\033[0;0m')
 				elif worker['type'] == "control":
 					pw = PiControlWorker(worker, main_thread_running, system_ready)
-					print('MudPi Controls...\t\t\t\033[1;32m Initializing\033[0;0m')
+					Logger.log(LOG_LEVEL["info"], 'MudPi Controls...\t\t\t\033[1;32m Initializing\033[0;0m')
 				elif worker['type'] == "i2c":
 					pw = PiI2CWorker(worker, main_thread_running, system_ready)
-					print('MudPi I2C...\t\t\t\t\033[1;32m Initializing\033[0;0m')
+					Logger.log(LOG_LEVEL["info"], 'MudPi I2C...\t\t\t\t\033[1;32m Initializing\033[0;0m')
 				elif worker['type'] == "display":
 					for display in worker['displays']:
 						display["redis"] = r
 						pw = LcdWorker(display, main_thread_running, system_ready, lcd_available)
 						lcd_available.set()
-						print('MudPi LCD Displays...\t\t\t\033[1;32m Initializing\033[0;0m')
+						Logger.log(LOG_LEVEL["info"], 'MudPi LCD Displays...\t\t\t\033[1;32m Initializing\033[0;0m')
 				elif worker['type'] == "relay":
 					# Add Relay Worker Here for Better Config Control
-					print('MudPi Relay...\t\t\t\033[1;32m Initializing\033[0;0m')
+					Logger.log(LOG_LEVEL["info"], 'MudPi Relay...\t\t\t\033[1;32m Initializing\033[0;0m')
 				else:
+					Logger.log(LOG_LEVEL["warning"], "Exception raised due to unknown Worker Type: {0}".format(worker['type']))
 					raise Exception("Unknown Worker Type: " + worker['type'])
 				workers.append(pw)
 	except KeyError as e:
-		print('MudPi Pi Workers...\t\t\t\033[1;31m Disabled\033[0;0m')
+		Logger.log(LOG_LEVEL["info"], 'MudPi Pi Workers...\t\t\t\033[1;31m Disabled\033[0;0m')
 		print(e)
 
 	# Worker for relays attached to pi
@@ -159,29 +174,29 @@ try:
 				relayState['available'].set()
 				relay_index +=1
 	except KeyError:
-		print('MudPi Relays Workers...\t\t\033[1;31m Disabled\033[0;0m')
+		Logger.log(LOG_LEVEL["info"], 'MudPi Relays Workers...\t\t\033[1;31m Disabled\033[0;0m')
 
 	# Load in Actions
 	try:
 		if len(CONFIGS["actions"]) > 0:
 			for action in CONFIGS["actions"]:
-				print('MudPi Actions...\t\t\t\033[1;32m Initializing\033[0;0m')
+				Logger.log(LOG_LEVEL["info"], 'MudPi Actions...\t\t\t\033[1;32m Initializing\033[0;0m')
 				action["redis"] = r
 				a = Action(action)
 				a.init_action()
 				actions[a.key] = a
 	except KeyError:
-		print('MudPi Actions...\t\t\t\033[1;31m Disabled\033[0;0m')
+		Logger.log(LOG_LEVEL["info"], 'MudPi Actions...\t\t\t\033[1;31m Disabled\033[0;0m')
 
 	# Worker for Triggers
 	try: 
 		if len(CONFIGS["triggers"]) > 0:
 			CONFIGS["triggers"]["redis"] = r
 			t = TriggerWorker(CONFIGS['triggers'], main_thread_running, system_ready, actions)
-			print('MudPi Triggers...\t\t\t\033[1;32m Initializing\033[0;0m')
+			Logger.log(LOG_LEVEL["info"], 'MudPi Triggers...\t\t\t\033[1;32m Initializing\033[0;0m')
 			workers.append(t)
 	except KeyError:
-		print('MudPi Triggers...\t\t\t\033[1;31m Disabled\033[0;0m')
+		Logger.log(LOG_LEVEL["info"], 'MudPi Triggers...\t\t\t\033[1;31m Disabled\033[0;0m')
 
 	# Worker for nodes attached to pi via serial or wifi[esp8266, esp32]
 	# Supported nodes: arduinos, esp8266, ADC-MCP3xxx, probably others (esp32 with custom nanpy fork)
@@ -191,36 +206,37 @@ try:
 				node["redis"] = r
 				if node['type'] == "arduino":
 					if NANPY_ENABLED:
-						print('MudPi Arduino Workers...\t\t\033[1;32m Initializing\033[0;0m')
+						Logger.log(LOG_LEVEL["info"], 'MudPi Arduino Workers...\t\t\033[1;32m Initializing\033[0;0m')
 						t = ArduinoWorker(node, main_thread_running, system_ready)
 					else:
-						print('Error Loading Nanpy library. Did you pip3 install -r requirements.txt?')
+						Logger.log(LOG_LEVEL["error"], 'Error Loading Nanpy library. Did you pip3 install -r requirements.txt?')
 				elif node['type'] == "ADC-MCP3008":
 					if MCP_ENABLED:
-						print('MudPi ADC Workers...\t\t\033[1;32m Initializing\033[0;0m')
+						Logger.log(LOG_LEVEL["info"], 'MudPi ADC Workers...\t\t\033[1;32m Initializing\033[0;0m')
 						t = ADCMCP3008Worker(node, main_thread_running, system_ready)
 					else:
-						print('Error Loading MCP3xxx library. Did you pip3 install -r requirements.txt;?')
+						Logger.log(LOG_LEVEL["error"], 'Error Loading MCP3xxx library. Did you pip3 install -r requirements.txt;?')
 				else:
+					Logger.log(LOG_LEVEL["warning"], "Exception raised due to unknown Node Type: {0}".format(node['type']))
 					raise Exception("Unknown Node Type: " + node['type'])
 				nodes.append(t)
 	except KeyError as e:
-		print('MudPi Node Workers...\t\t\t\033[1;31m Disabled\033[0;0m')
+		Logger.log(LOG_LEVEL["info"], 'MudPi Node Workers...\t\t\t\033[1;31m Disabled\033[0;0m')
 
 	try:
 		if (CONFIGS['server'] is not None):
-			print('MudPi Server...\t\t\t\t\033[1;33m Starting\033[0;0m', end='\r', flush=True)
+			Logger.log(LOG_LEVEL["info"], 'MudPi Server...\t\t\t\t\033[1;33m Starting\033[0;0m', end='\r', flush=True)
 			time.sleep(1)
 			server = MudpiServer(main_thread_running, CONFIGS['server']['host'], CONFIGS['server']['port'])
-			s = threading.Thread(target=server_worker)
+			s = threading.Thread(target=server_worker)  # TODO where is server_worker supposed to be initialized?
 			threads.append(s)
 			s.start()
 	except KeyError:
-		print('MudPi Socket Server...\t\t\t\033[1;31m Disabled\033[0;0m')
+		Logger.log(LOG_LEVEL["info"], 'MudPi Socket Server...\t\t\t\033[1;31m Disabled\033[0;0m')
 
 
-	print('MudPi Garden Controls...\t\t\033[1;32m Initialized\033[0;0m')
-	print('Engaging MudPi Workers...\t\t\033[1;32m \033[0;0m')
+	Logger.log(LOG_LEVEL["info"], 'MudPi Garden Controls...\t\t\033[1;32m Initialized\033[0;0m')
+	Logger.log(LOG_LEVEL["info"], 'Engaging MudPi Workers...\t\t\033[1;32m \033[0;0m')
 	for worker in workers:
 		t = worker.run()
 		threads.append(t)
@@ -231,8 +247,8 @@ try:
 		time.sleep(.5)
 
 	time.sleep(.5)
-	print('MudPi Garden Control...\t\t\t\033[1;32m Online\033[0;0m')
-	print('_________________________________________________')
+	Logger.log(LOG_LEVEL["info"], 'MudPi Garden Control...\t\t\t\033[1;32m Online\033[0;0m')
+	Logger.log(LOG_LEVEL["info"], '_________________________________________________')
 	system_ready.set() #Workers will not process until system is ready
 	r.set('started_at', str(datetime.datetime.now())) #Store current time to track uptime
 	system_message = {'event':'SystemStarted', 'data':1}
@@ -247,7 +263,7 @@ try:
 except KeyboardInterrupt:
 	PROGRAM_RUNNING = False
 finally:
-	print('MudPi Shutting Down...')
+	Logger.log(LOG_LEVEL["info"], 'MudPi Shutting Down...')
 	# Perform any cleanup tasks here...
 
 	try:
@@ -265,6 +281,6 @@ finally:
 	for thread in threads:
 		thread.join()
 
-	print("MudPi Shutting Down...\t\t\t\033[1;32m Complete\033[0;0m")
-	print("Mudpi is Now...\t\t\t\t\033[1;31m Offline\033[0;0m")
+	Logger.log(LOG_LEVEL["info"], "MudPi Shutting Down...\t\t\t\033[1;32m Complete\033[0;0m")
+	Logger.log(LOG_LEVEL["info"], "Mudpi is Now...\t\t\t\t\033[1;31m Offline\033[0;0m")
 	

--- a/sensors/MCP3xxx/soil_sensor.py
+++ b/sensors/MCP3xxx/soil_sensor.py
@@ -6,6 +6,8 @@ from .sensor import Sensor
 import sys
 from adafruit_mcp3xxx.analog_in import AnalogIn
 
+from logger.Logger import Logger, LOG_LEVEL
+
 sys.path.append('..')
 
 #  Tested using Sun3Drucker Model SX239
@@ -41,5 +43,5 @@ class SoilSensor(Sensor):
         self.r.set(self.key,
                         resistance)  # TODO: CHANGE BACK TO 'moistpercent' (PERSONAL CONFIG)
 
-        print("moisture: {0}".format(moisture))
+        Logger.log(LOG_LEVEL["debug"], "moisture: {0}".format(moisture))
         return resistance

--- a/sensors/arduino/temperature_sensor.py
+++ b/sensors/arduino/temperature_sensor.py
@@ -5,6 +5,8 @@ import redis
 from .sensor import Sensor
 from nanpy import (DallasTemperature, SerialManager)
 import sys
+
+from logger.Logger import Logger, LOG_LEVEL
 sys.path.append('..')
 
 import variables
@@ -22,13 +24,13 @@ class TemperatureSensor(Sensor):
 		self.sensors = DallasTemperature(self.pin, connection=self.connection)
 		self.sensor_bus = self.sensors.getDeviceCount()
 		# read data using pin specified pin
-		print("There are",self.sensor_bus, "devices connected on pin ", self.sensors.pin)
+		Logger.log(LOG_LEVEL["debug"], "There are",self.sensor_bus, "devices connected on pin ", self.sensors.pin)
 		self.addresses = []
 
 		for i in range(self.sensor_bus):
 			self.addresses.append(self.sensors.getAddress(i))
 
-		print("There addresses", self.addresses)
+		Logger.log(LOG_LEVEL["debug"], "Their addresses", self.addresses)
 		#I guess this is something with bit rates? TODO: Look this up
 		self.sensors.setResolution(10)
 

--- a/sensors/pi/humidity_sensor.py
+++ b/sensors/pi/humidity_sensor.py
@@ -7,6 +7,8 @@ import Adafruit_DHT
 import sys
 sys.path.append('..')
 
+from logger.Logger import Logger, LOG_LEVEL
+
 #r = redis.Redis(host='127.0.0.1', port=6379)
 #PIN MODE : OUT | IN
 
@@ -25,7 +27,7 @@ class HumiditySensor(Sensor):
 		if self.type in sensor_types:
 			self.sensor = sensor_types[self.type]
 		else:
-			print('Sensor Model Error: Defaulting to DHT11')
+			Logger.log(LOG_LEVEL["warning"], 'Sensor Model Error: Defaulting to DHT11')
 			self.sensor = Adafruit_DHT.DHT11
 		return
 
@@ -41,7 +43,7 @@ class HumiditySensor(Sensor):
 			self.r.set(self.key, json.dumps(readings))
 			return readings
 		else:
-			print('Failed to get DHT reading. Try again!')
+			Logger.log(LOG_LEVEL["error"], 'Failed to get DHT reading. Try again!')
 
 
 	def readRaw(self):

--- a/sensors/pi/i2c/bme680_sensor.py
+++ b/sensors/pi/i2c/bme680_sensor.py
@@ -6,6 +6,8 @@ import board
 from busio import I2C
 import adafruit_bme680
 
+from logger.Logger import Logger, LOG_LEVEL
+
 import sys
 sys.path.append('..')
 
@@ -42,7 +44,7 @@ class Bme680Sensor(Sensor):
 			# print('BME680:', readings)
 			return readings
 		else:
-			print('Failed to get reading [BME680]. Try again!')
+			Logger.log(LOG_LEVEL["error"], 'Failed to get reading [BME680]. Try again!')
 
 	def readRaw(self):
 		#Read the sensor(s) but return the raw data, useful for debugging

--- a/server/mudpi_server.py
+++ b/server/mudpi_server.py
@@ -3,6 +3,8 @@ import sys
 import threading
 import pickle
 
+from logger.Logger import Logger, LOG_LEVEL
+
 # A socket server prototype that was going to be used for devices to communicate.
 # Instead we are using nodejs to catch events in redis and emit them over a socket.
 # May update this in later version for device communications. Undetermined.
@@ -19,17 +21,17 @@ class MudpiServer(object):
 		try:
 			self.sock.bind((self.host, self.port))
 		except socket.error as msg:
-			print('Failed to create socket. Error Code: ', str(msg[0]), ' , Error Message: ', msg[1])
+			Logger.log(LOG_LEVEL["error"], 'Failed to create socket. Error Code: ', str(msg[0]), ' , Error Message: ', msg[1])
 			sys.exit()
 
 	def listen(self):
 		self.sock.listen(10) #number of clients to listen for
-		print('MudPi Server...\t\t\t\t\033[1;32m Online\033[0;0m ')
+		Logger.log(LOG_LEVEL["info"], 'MudPi Server...\t\t\t\t\033[1;32m Online\033[0;0m ')
 		while self.system_running.is_set():
 			try:
 				client, address = self.sock.accept()
 				client.settimeout(60)
-				print('Client connected from ', address)
+				Logger.log(LOG_LEVEL["debug"], 'Client connected from ', address)
 				t = threading.Thread(target = self.listenToClient, args = (client, address))
 				self.client_threads.append(t)
 				t.start()
@@ -37,7 +39,7 @@ class MudpiServer(object):
 				pass
 		print('Server Shutdown...\r', end="", flush=True)
 		self.sock.close()
-		print('Server Shutdown...\t\t\t\033[1;32m Complete\033[0;0m')
+		Logger.log(LOG_LEVEL["info"], 'Server Shutdown...\t\t\t\033[1;32m Complete\033[0;0m')
 
 	def listenToClient(self, client, address):
 		size = 1024
@@ -53,7 +55,7 @@ class MudpiServer(object):
 			except:
 				client.close()
 				return false
-		print('Closing Client Connection...\t\t\033[1;32m Complete\033[0;0m')
+		Logger.log(LOG_LEVEL["info"], 'Closing Client Connection...\t\t\033[1;32m Complete\033[0;0m')
 
 if __name__ == "__main__":
 	host = '127.0.0.1'

--- a/triggers/control_trigger.py
+++ b/triggers/control_trigger.py
@@ -5,6 +5,8 @@ import sys
 from .trigger import Trigger
 sys.path.append('..')
 
+from logger.Logger import Logger, LOG_LEVEL
+
 class ControlTrigger(Trigger):
 
 	def __init__(self, main_thread_running, system_ready, name='ControlTrigger',key=None, source=None, thresholds=None, topic="controls", trigger_active=None, frequency='once', actions=[], group=None, redis_conn=None):
@@ -51,7 +53,7 @@ class ControlTrigger(Trigger):
 					else:
 						self.trigger_active.clear()
 			except:
-				print('Error During Trigger Actions {0}'.format(self.key))
+				Logger.log(LOG_LEVEL["error"], 'Error During Trigger Actions {0}'.format(self.key))
 		self.previous_state = self.trigger_active.is_set()
 
 	def parseControlData(self, data):

--- a/triggers/sensor_trigger.py
+++ b/triggers/sensor_trigger.py
@@ -5,6 +5,8 @@ import sys
 from .trigger import Trigger
 sys.path.append('..')
 
+from logger.Logger import Logger, LOG_LEVEL
+
 class SensorTrigger(Trigger):
 
 	def __init__(self, main_thread_running, system_ready, name='SensorTrigger',key=None, source=None, nested_source=None, thresholds=None, topic="sensors", trigger_active=None, frequency='once', actions=[], group=None, redis_conn=None):
@@ -52,7 +54,7 @@ class SensorTrigger(Trigger):
 					else:
 						self.trigger_active.clear()
 			except:
-				print('Error Triggering Actions for {0}'.format(self.name))
+				Logger.log(LOG_LEVEL["error"], 'Error Triggering Actions for {0}'.format(self.name))
 		self.previous_state = self.trigger_active.is_set()
 
 	def parseSensorData(self, data):

--- a/triggers/time_trigger.py
+++ b/triggers/time_trigger.py
@@ -10,6 +10,8 @@ except ImportError:
 	CRON_ENABLED = False
 sys.path.append('..')
 
+from logger.Logger import Logger, LOG_LEVEL
+
 class TimeTrigger(Trigger):
 
 	def __init__(self, main_thread_running, system_ready, name='TimeTrigger',key=None, trigger_active=None, actions=[], schedule=None, group=None):
@@ -33,9 +35,9 @@ class TimeTrigger(Trigger):
 						else:
 							self.trigger_active.clear()
 					else:
-						print("Error pycron not found.")
+						Logger.log(LOG_LEVEL["error"], "Error pycron not found.")
 				except:
-					print("Error evaluating time trigger schedule.")
+					Logger.log(LOG_LEVEL["error"], "Error evaluating time trigger schedule.")
 				time.sleep(self.trigger_interval)
 			else:
 				time.sleep(2)

--- a/triggers/trigger.py
+++ b/triggers/trigger.py
@@ -5,6 +5,8 @@ import threading
 import sys
 sys.path.append('..')
 
+from logger.Logger import Logger, LOG_LEVEL
+
 class Trigger():
 
 	def __init__(self, main_thread_running, system_ready, name='Trigger',key=None, source=None, thresholds=None, trigger_active=None, frequency='once', actions=[], trigger_interval=1, group=None):
@@ -48,7 +50,7 @@ class Trigger():
 			else:
 				self.group.trigger()
 		except Exception as e:
-			print("Error triggering action {0} ".format(self.key), e)
+			Logger.log(LOG_LEVEL["error"], "Error triggering action {0} ".format(self.key), e)
 			pass
 		return
 

--- a/triggers/trigger_group.py
+++ b/triggers/trigger_group.py
@@ -5,6 +5,8 @@ import threading
 import sys
 sys.path.append('..')
 
+from logger.Logger import Logger, LOG_LEVEL
+
 class TriggerGroup():
 
 	def __init__(self, name='TriggerGroup', key=None, triggers=[], group_active=None, frequency='once', actions=[]):
@@ -50,7 +52,7 @@ class TriggerGroup():
 			else:
 				self.trigger_count = 0
 		except Exception as e:
-			print("Error triggering group {0} ".format(self.key), e)
+			Logger.log(LOG_LEVEL["error"], "Error triggering group {0} ".format(self.key), e)
 			pass
 		return
 

--- a/workers/adc_worker.py
+++ b/workers/adc_worker.py
@@ -8,6 +8,7 @@ import time
 import json
 import redis
 import importlib
+from logger.Logger import Logger, LOG_LEVEL
 
 
 class ADCMCP3008Worker:
@@ -81,17 +82,17 @@ class ADCMCP3008Worker:
                                              mcp=self.mcp)
                 new_sensor.init_sensor()
                 self.sensors.append(new_sensor)
-                print('{type} Sensor {pin}...\t\t\t\033[1;32m Ready\033[0;0m'.format(**sensor))
+                Logger.log(LOG_LEVEL["info"], '{type} Sensor {pin}...\t\t\t\033[1;32m Ready\033[0;0m'.format(**sensor))
 
     def run(self):
         if self.node_ready:
             t = threading.Thread(target=self.work, args=())
             t.start()
-            print(str(self.config['name']) + ' Node Worker [' + str(
+            Logger.log(LOG_LEVEL["info"], str(self.config['name']) + ' Node Worker [' + str(
                 len(self.config['sensors'])) + ' Sensors]...\t\033[1;32m Online\033[0;0m')
             return t
         else:
-            print("Node Connection...\t\t\t\033[1;31m Failed\033[0;0m")
+            Logger.log(LOG_LEVEL["warning"], "Node Connection...\t\t\t\033[1;31m Failed\033[0;0m")
             return None
 
     def work(self):
@@ -105,11 +106,11 @@ class ADCMCP3008Worker:
                     readings[sensor.key] = result
                 # r.set(sensor.get('key', sensor.get('type')), value)
 
-                print(readings)
+                Logger.log(LOG_LEVEL["info"], readings)
                 message['data'] = readings
                 self.r.publish('sensors', json.dumps(message))
 
             time.sleep(15)
         # This is only ran after the main thread is shut down
-        print("{name} Node Worker Shutting Down...\t\t\033[1;32m Complete\033[0;0m".format(
+        Logger.log(LOG_LEVEL["info"], "{name} Node Worker Shutting Down...\t\t\033[1;32m Complete\033[0;0m".format(
             **self.config))

--- a/workers/arduino/arduino_control_worker.py
+++ b/workers/arduino/arduino_control_worker.py
@@ -12,6 +12,7 @@ sys.path.append('..')
 
 import variables
 import importlib
+from logger.Logger import Logger, LOG_LEVEL
 
 #r = redis.Redis(host='127.0.0.1', port=6379)
 
@@ -83,7 +84,7 @@ class ArduinoControlWorker(Worker):
 								result = control.read()
 								readings[control.key] = result
 						except (SerialManagerError, SocketManagerError, BrokenPipeError, ConnectionResetError, OSError, socket.timeout) as e:
-							print('\033[1;36m{name}\033[0;0m -> \033[1;33mControls Timeout!\033[0;0m'.format(**self.config))
+							Logger.log(LOG_LEVEL["warning"], '\033[1;36m{name}\033[0;0m -> \033[1;33mControls Timeout!\033[0;0m'.format(**self.config))
 							self.controls_ready = False
 							self.controls = []
 							self.node_connected.clear()
@@ -99,4 +100,4 @@ class ArduinoControlWorker(Worker):
 			#Will this nuke the connection?	
 			time.sleep(0.05)
 		#This is only ran after the main thread is shut down
-		print("{name} Controls Shutting Down...\t\033[1;32m Complete\033[0;0m".format(**self.config))
+		Logger.log(LOG_LEVEL["info"], "{name} Controls Shutting Down...\t\033[1;32m Complete\033[0;0m".format(**self.config))

--- a/workers/arduino/arduino_relay_worker.py
+++ b/workers/arduino/arduino_relay_worker.py
@@ -12,6 +12,7 @@ from .worker import Worker
 sys.path.append('..')
 
 import variables
+from logger.Logger import Logger, LOG_LEVEL
 
 class ArduinoRelayWorker(Worker):
 	def __init__(self, config, main_thread_running, system_ready, relay_available, relay_active, node_connected, connection=None, api=None):
@@ -40,7 +41,7 @@ class ArduinoRelayWorker(Worker):
 		return
 
 	def init(self):
-		print('{name} Relay Worker {key}...\t\t\033[1;32m Initializing\033[0;0m'.format(**self.config))
+		Logger.log(LOG_LEVEL["info"], '{name} Relay Worker {key}...\t\t\033[1;32m Initializing\033[0;0m'.format(**self.config))
 		self.api = self.api if self.api is not None else ArduinoApi(connection)
 		self.pin_state_off = self.api.HIGH if self.config['normally_open'] is not None and self.config['normally_open'] else self.api.LOW
 		self.pin_state_on = self.api.LOW if self.config['normally_open'] is not None and self.config['normally_open'] else self.api.HIGH
@@ -53,7 +54,7 @@ class ArduinoRelayWorker(Worker):
 		if(self.config.get('restore_last_known_state', None) is not None and self.config.get('restore_last_known_state', False) is True):
 			if(self.r.get(self.config['key']+'_state')):
 				self.api.digitalWrite(self.config['pin'], self.pin_state_on)
-				print('Restoring Relay \033[1;36m{0} On\033[0;0m'.format(self.config['key']))
+				Logger.log(LOG_LEVEL["warning"], 'Restoring Relay \033[1;36m{0} On\033[0;0m'.format(self.config['key']))
 
 		self.relay_ready = True
 		return
@@ -61,7 +62,7 @@ class ArduinoRelayWorker(Worker):
 	def run(self): 
 		t = threading.Thread(target=self.work, args=())
 		t.start()
-		print('Node Relay {key} Worker...\t\t\033[1;32m Online\033[0;0m'.format(**self.config))
+		Logger.log(LOG_LEVEL["info"], 'Node Relay {key} Worker...\t\t\033[1;32m Online\033[0;0m'.format(**self.config))
 		return t
 
 	def decodeMessageData(self, message):
@@ -90,16 +91,16 @@ class ArduinoRelayWorker(Worker):
 						self.relay_active.set()
 					elif decoded_message.get('data', None) == 0:
 						self.relay_active.clear()
-					print('Switch Relay \033[1;36m{0}\033[0;0m state to \033[1;36m{1}\033[0;0m'.format(self.config['key'], decoded_message['data']))
+					Logger.log(LOG_LEVEL["info"], 'Switch Relay \033[1;36m{0}\033[0;0m state to \033[1;36m{1}\033[0;0m'.format(self.config['key'], decoded_message['data']))
 				elif decoded_message['event'] == 'Toggle':
 					state = 'Off' if self.active else 'On'
 					if self.relay_active.is_set():
 						self.relay_active.clear()
 					else:
 						self.relay_active.set()
-					print('Toggle Relay \033[1;36m{0} {1} \033[0;0m'.format(self.config['key'], state))
+					Logger.log(LOG_LEVEL["info"], 'Toggle Relay \033[1;36m{0} {1} \033[0;0m'.format(self.config['key'], state))
 			except:
-				print('Error Decoding Message for Relay {0}'.format(self.config['key']))
+				Logger.log(LOG_LEVEL["error"], 'Error Decoding Message for Relay {0}'.format(self.config['key']))
 
 	def elapsedTime(self):
 		self.time_elapsed = time.perf_counter() - self.time_start
@@ -150,8 +151,8 @@ class ArduinoRelayWorker(Worker):
 								self.turnOff()
 								time.sleep(1)
 						except e:
-							print("Node Relay Worker \033[1;36m{key}\033[0;0m \t\033[1;31m Unexpected Error\033[0;0m".format(**self.config))
-							print(e)
+							Logger.log(LOG_LEVEL["error"], "Node Relay Worker \033[1;36m{key}\033[0;0m \t\033[1;31m Unexpected Error\033[0;0m".format(**self.config))
+							Logger.log(LOG_LEVEL["error"], "Exception: {0}".format(e))
 					else:
 						self.init()
 				else: 
@@ -171,4 +172,4 @@ class ArduinoRelayWorker(Worker):
 		#This is only ran after the main thread is shut down
 		#Close the pubsub connection
 		self.pubsub.close()
-		print("Node Relay {key} Shutting Down...\t\033[1;32m Complete\033[0;0m".format(**self.config))
+		Logger.log(LOG_LEVEL["info"], "Node Relay {key} Shutting Down...\t\033[1;32m Complete\033[0;0m".format(**self.config))

--- a/workers/arduino/arduino_sensor_worker.py
+++ b/workers/arduino/arduino_sensor_worker.py
@@ -17,6 +17,7 @@ import sys
 sys.path.append('..')
 
 import importlib
+from logger.Logger import Logger, LOG_LEVEL
 
 #r = redis.Redis(host='127.0.0.1', port=6379)
 
@@ -35,7 +36,7 @@ class ArduinoSensorWorker(Worker):
 		return
 
 	def init(self, connection=None):
-		print('{name} Sensor Worker...\t\t\033[1;32m Preparing\033[0;0m'.format(**self.config))
+		Logger.log(LOG_LEVEL["info"], '{name} Sensor Worker...\t\t\033[1;32m Preparing\033[0;0m'.format(**self.config))
 		try:
 			for sensor in self.config['sensors']:
 				if sensor.get('type', None) is not None:
@@ -78,7 +79,7 @@ class ArduinoSensorWorker(Worker):
 	def run(self):
 		t = threading.Thread(target=self.work, args=())
 		t.start()
-		print('Node {name} Sensor Worker...\t\t\033[1;32m Online\033[0;0m'.format(**self.config))
+		Logger.log(LOG_LEVEL["info"], 'Node {name} Sensor Worker...\t\t\033[1;32m Online\033[0;0m'.format(**self.config))
 		return t
 
 	def work(self):
@@ -94,11 +95,11 @@ class ArduinoSensorWorker(Worker):
 								readings[sensor.key] = result
 								#r.set(sensor.get('key', sensor.get('type')), value)
 								
-							print("Node Readings: ", readings)
+							Logger.log(LOG_LEVEL["debug"], "Node Readings: ", readings)
 							message['data'] = readings
 							self.r.publish(self.topic, json.dumps(message))
 						except (SerialManagerError, SocketManagerError, BrokenPipeError, ConnectionResetError, OSError, socket.timeout) as e:
-							print('\033[1;36m{name}\033[0;0m -> \033[1;33mSensors Timeout!\033[0;0m'.format(**self.config))
+							Logger.log(LOG_LEVEL["warning"], '\033[1;36m{name}\033[0;0m -> \033[1;33mSensors Timeout!\033[0;0m'.format(**self.config))
 							self.sensors = []
 							self.node_connected.clear()
 							time.sleep(15)
@@ -115,4 +116,4 @@ class ArduinoSensorWorker(Worker):
 			time.sleep(self.sleep_duration)
 
 		#This is only ran after the main thread is shut down
-		print("{name} Sensors Shutting Down...\t\033[1;32m Complete\033[0;0m".format(**self.config))
+		Logger.log(LOG_LEVEL["info"], "{name} Sensors Shutting Down...\t\033[1;32m Complete\033[0;0m".format(**self.config))

--- a/workers/arduino/worker.py
+++ b/workers/arduino/worker.py
@@ -6,6 +6,8 @@ import threading
 import sys
 sys.path.append('..')
 
+from logger.Logger import Logger, LOG_LEVEL
+
 # Base Worker Class
 # A worker is responsible for handling its set of operations and running on a thread
 class Worker():
@@ -41,7 +43,7 @@ class Worker():
 			if self.system_ready.is_set():
 				time.sleep(self.sleep_duration)
 		#This is only ran after the main thread is shut down
-		print("Worker Shutting Down...\t\033[1;32m Complete\033[0;0m")
+		Logger.log(LOG_LEVEL["info"], "Worker Shutting Down...\t\033[1;32m Complete\033[0;0m")
 
 	def dynamic_import(self, name):
 		# Split path of the class folder structure: {sensor name}_sensor . {SensorName}Sensor

--- a/workers/pi/control_worker.py
+++ b/workers/pi/control_worker.py
@@ -9,6 +9,8 @@ sys.path.append('..')
 from controls.pi.button_control import (ButtonControl)
 from controls.pi.switch_control import (SwitchControl)
 
+from logger.Logger import Logger, LOG_LEVEL
+
 class PiControlWorker(Worker):
 	def __init__(self, config, main_thread_running, system_ready):
 		super().__init__(config, main_thread_running, system_ready)
@@ -46,11 +48,11 @@ class PiControlWorker(Worker):
 
 				new_control.init_control()
 				self.controls.append(new_control)
-				print('{type} Control {pin}...\t\t\t\033[1;32m Ready\033[0;0m'.format(**control))
+				Logger.log(LOG_LEVEL["info"], '{type} Control {pin}...\t\t\t\033[1;32m Ready\033[0;0m'.format(**control))
 		return
 
 	def run(self): 
-		print('Pi Control Worker [' + str(len(self.config['controls'])) + ' Controls]...\t\033[1;32m Online\033[0;0m')
+		Logger.log(LOG_LEVEL["info"], 'Pi Control Worker [' + str(len(self.config['controls'])) + ' Controls]...\t\033[1;32m Online\033[0;0m')
 		return super().run()
 
 	def work(self):
@@ -62,4 +64,4 @@ class PiControlWorker(Worker):
 					readings[control.key] = result
 			time.sleep(self.sleep_duration)
 		#This is only ran after the main thread is shut down
-		print("Pi Control Worker Shutting Down...\t\033[1;32m Complete\033[0;0m")
+		Logger.log(LOG_LEVEL["info"], "Pi Control Worker Shutting Down...\t\033[1;32m Complete\033[0;0m")

--- a/workers/pi/i2c_worker.py
+++ b/workers/pi/i2c_worker.py
@@ -8,6 +8,8 @@ sys.path.append('..')
 from .worker import Worker
 from sensors.pi.i2c.bme680_sensor import (Bme680Sensor)
 
+from logger.Logger import Logger, LOG_LEVEL
+
 
 class PiI2CWorker(Worker):
 	def __init__(self, config, main_thread_running, system_ready):
@@ -50,7 +52,7 @@ class PiI2CWorker(Worker):
 		return
 
 	def run(self): 
-		print('Pi I2C Sensor Worker [' + str(len(self.sensors)) + ' Sensors]...\t\033[1;32m Online\033[0;0m')
+		Logger.log(LOG_LEVEL["info"], 'Pi I2C Sensor Worker [' + str(len(self.sensors)) + ' Sensors]...\t\033[1;32m Online\033[0;0m')
 		return super().run()
 
 	def work(self):
@@ -66,10 +68,10 @@ class PiI2CWorker(Worker):
 					self.r.set(sensor.key, json.dumps(result))
 				
 				message['data'] = readings
-				print(readings);
+				Logger.log(LOG_LEVEL["debug"], readings);
 				self.r.publish(self.topic, json.dumps(message))
 				time.sleep(self.sleep_duration)
 				
 			time.sleep(2)
 		#This is only ran after the main thread is shut down
-		print("Pi I2C Sensor Worker Shutting Down...\t\033[1;32m Complete\033[0;0m")
+		Logger.log(LOG_LEVEL["info"], "Pi I2C Sensor Worker Shutting Down...\t\033[1;32m Complete\033[0;0m")

--- a/workers/pi/lcd_worker.py
+++ b/workers/pi/lcd_worker.py
@@ -11,6 +11,8 @@ from .worker import Worker
 import sys
 sys.path.append('..')
 
+from logger.Logger import Logger, LOG_LEVEL
+
 class LcdWorker(Worker):
 	def __init__(self, config, main_thread_running, system_ready, lcd_available):
 		super().__init__(config, main_thread_running, system_ready)
@@ -57,7 +59,7 @@ class LcdWorker(Worker):
 		return
 
 	def init(self):
-		print('LCD Display Worker...\t\t\t\033[1;32m Initializing\033[0;0m'.format(**self.config))
+		Logger.log(LOG_LEVEL["info"], 'LCD Display Worker...\t\t\t\033[1;32m Initializing\033[0;0m'.format(**self.config))
 		# prepare sensor on specified pin
 		self.i2c = busio.I2C(board.SCL, board.SDA)
 		if(self.model):
@@ -74,7 +76,7 @@ class LcdWorker(Worker):
 		return
 
 	def run(self): 
-		print('LCD Display Worker ...\t\t\t\033[1;32m Online\033[0;0m'.format(**self.config))
+		Logger.log(LOG_LEVEL["info"], 'LCD Display Worker ...\t\t\t\033[1;32m Online\033[0;0m'.format(**self.config))
 		return super().run()
 
 	def handleMessage(self, message):
@@ -85,15 +87,15 @@ class LcdWorker(Worker):
 				if decoded_message['event'] == 'Message':
 					if decoded_message.get('data', None):
 						self.addMessageToQueue(decoded_message['data'].get('message', ''), int(decoded_message['data'].get('duration', self.default_duration)))
-						print('LCD Message Queued: \033[1;36m{0}\033[0;0m'.format(decoded_message['data']))
+						Logger.log(LOG_LEVEL["debug"], 'LCD Message Queued: \033[1;36m{0}\033[0;0m'.format(decoded_message['data']))
 				elif decoded_message['event'] == 'Clear':
 					self.lcd.clear()
-					print('Cleared the LCD Screen')
+					Logger.log(LOG_LEVEL["debug"], 'Cleared the LCD Screen')
 				elif decoded_message['event'] == 'ClearQueue':
 					self.message_queue = []
-					print('Cleared the LCD Message Queue')
+					Logger.log(LOG_LEVEL["debug"], 'Cleared the LCD Message Queue')
 			except:
-				print('Error Decoding Message for LCD')
+				Logger.log(LOG_LEVEL["error"], 'Error Decoding Message for LCD')
 	
 	def addMessageToQueue(self, message, duration = 3):
 		#Add message to queue if LCD available
@@ -140,8 +142,8 @@ class LcdWorker(Worker):
 					else:
 						time.sleep(1)
 				except Exception as e:
-					print("LCD Worker \t\033[1;31m Unexpected Error\033[0;0m".format(**self.config))
-					print(e)
+					Logger.log(LOG_LEVEL["error"], "LCD Worker \t\033[1;31m Unexpected Error\033[0;0m".format(**self.config))
+					Logger.log(LOG_LEVEL["error"], "Exception: {0}".format(e)) 
 			else:
 				#System not ready
 				time.sleep(1)
@@ -152,4 +154,4 @@ class LcdWorker(Worker):
 		#This is only ran after the main thread is shut down
 		#Close the pubsub connection
 		self.pubsub.close()
-		print("LCD Worker Shutting Down...\t\t\033[1;32m Complete\033[0;0m".format(**self.config))
+		Logger.log(LOG_LEVEL["info"], "LCD Worker Shutting Down...\t\t\033[1;32m Complete\033[0;0m".format(**self.config))

--- a/workers/pi/sensor_worker.py
+++ b/workers/pi/sensor_worker.py
@@ -8,6 +8,7 @@ import sys
 sys.path.append('..')
 from sensors.pi.float_sensor import (FloatSensor)
 from sensors.pi.humidity_sensor import (HumiditySensor)
+from logger.Logger import Logger, LOG_LEVEL
 
 class PiSensorWorker(Worker):
 	def __init__(self, config, main_thread_running, system_ready):
@@ -54,7 +55,7 @@ class PiSensorWorker(Worker):
 		return
 
 	def run(self): 
-		print('Pi Sensor Worker [' + str(len(self.sensors)) + ' Sensors]...\t\t\033[1;32m Online\033[0;0m')
+		Logger.log(LOG_LEVEL["info"], 'Pi Sensor Worker [' + str(len(self.sensors)) + ' Sensors]...\t\t\033[1;32m Online\033[0;0m')
 		return super().run()
 
 	def work(self):
@@ -85,4 +86,4 @@ class PiSensorWorker(Worker):
 				
 			time.sleep(2)
 		#This is only ran after the main thread is shut down
-		print("Pi Sensor Worker Shutting Down...\t\033[1;32m Complete\033[0;0m")
+		Logger.log(LOG_LEVEL["info"], "Pi Sensor Worker Shutting Down...\t\033[1;32m Complete\033[0;0m")

--- a/workers/pi/worker.py
+++ b/workers/pi/worker.py
@@ -7,6 +7,7 @@ import sys
 sys.path.append('..')
 
 import variables
+from logger.Logger import Logger, LOG_LEVEL
 
 def log(func):
 	def wrapper(*args, **kwargs):
@@ -48,7 +49,7 @@ class Worker():
 			if self.system_ready.is_set():
 				time.sleep(self.sleep_duration)
 		#This is only ran after the main thread is shut down
-		print("Worker Shutting Down...\t\033[1;32m Complete\033[0;0m")
+		Logger.log(LOG_LEVEL["info"], "Worker Shutting Down...\t\033[1;32m Complete\033[0;0m")
 
 	def elapsedTime(self):
 		self.time_elapsed = time.perf_counter() - self.time_start

--- a/workers/trigger_worker.py
+++ b/workers/trigger_worker.py
@@ -10,6 +10,7 @@ from triggers.trigger_group import TriggerGroup
 
 import variables
 import importlib
+from logger.Logger import Logger, LOG_LEVEL
 
 class TriggerWorker(Worker):
 	def __init__(self, config, main_thread_running, system_ready, actions):
@@ -110,7 +111,7 @@ class TriggerWorker(Worker):
 			return new_trigger
 
 	def run(self): 
-		print('Trigger Worker [' + str(len(self.config)) + ' Triggers]...\t\t\033[1;32m Online\033[0;0m')
+		Logger.log(LOG_LEVEL["info"], 'Trigger Worker [' + str(len(self.config)) + ' Triggers]...\t\t\033[1;32m Online\033[0;0m')
 		return super().run()
 
 	def work(self):
@@ -126,4 +127,4 @@ class TriggerWorker(Worker):
 		# Join all our sub threads for shutdown
 		for thread in self.trigger_threads:
 			thread.join()
-		print("Trigger Worker Shutting Down...\t\t\033[1;32m Complete\033[0;0m")
+		Logger.log(LOG_LEVEL["info"], "Trigger Worker Shutting Down...\t\t\033[1;32m Complete\033[0;0m")

--- a/workers/worker.py
+++ b/workers/worker.py
@@ -7,6 +7,7 @@ import sys
 sys.path.append('..')
 
 import variables
+from logger.Logger import Logger, LOG_LEVEL
 
 def log(func):
 	def wrapper(*args, **kwargs):
@@ -41,7 +42,7 @@ class Worker():
 			if self.system_ready.is_set():
 				time.sleep(self.sleep_duration)
 		#This is only ran after the main thread is shut down
-		print("Worker Shutting Down...\t\033[1;32m Complete\033[0;0m")
+		Logger.log(LOG_LEVEL["info"], "Worker Shutting Down...\t\033[1;32m Complete\033[0;0m")
 
 	def elapsedTime(self):
 		self.time_elapsed = time.perf_counter() - self.time_start


### PR DESCRIPTION
# Changes

## New Logger Class
Created `logger/Logger.py` which is to be initialized by `mudpi.py`  early on. To avoid the complications of passing an instance around of the logger the current logger instance is a static member on the Logger Class (see `Logger.logger`).

To ease and shorten access even further I've added static methods that direct their parameters to this Logger instance. So that `Logger.log(someLevel, someMessage)` suffices (assuming prior initialization).

## Logger Usage
The `logger/Logger.py` introduces a dictionary for access to the log levels.
When logging all messages are written also to a log file (if set up in the configs) with a different format `[%(asctime)s][%(name)s][%(levelname)s] %(message)s` while they are printed unedited to stdout.

The logging module allows to place different logging levels for each handler (stdout or log file) therefore for each a different log level is configurable.

### Example
#### Code
```py
Logger.log(LOG_LEVEL["info"], 'Initializing Logger...\t\t\t\033[1;32m Complete\033[0;0m')
```
#### stdout (Supports Text Color, just not in this post)
```
Initializing Logger...                   Complete
```
#### Log File (default mudpi.log)
```
[15:24:14][EVE][INFO] Initializing Logger...			 Complete
```

Note: It is possible to just log to a file via `Logger.log_to_file()`.

## Config
```
"logging": {
        "file_log_level": "debug",
        "terminal_log_level": "debug",
        "file": "mudpi.log"
    },
```
I've edited the mudpi.config.example to include verbose logging defaults. If the logging levels are set higher the lower ones (debug, info, ...) are not printed/written.

If debugging is set to true in the configuration all logging levels are automatically set to "debug" regardless of the configuration.